### PR TITLE
Handle null results in pickWeighted

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,7 +275,9 @@
   }
 
   function pickWeighted(arr, key) {
+    if (arr.length === 0) return null;
     const total = arr.reduce((a, b) => a + b[key], 0);
+    if (total === 0) return null;
     let r = Math.random() * total;
     for (const it of arr) { r -= it[key]; if (r <= 0) return it; }
     return arr[arr.length - 1];
@@ -283,6 +285,7 @@
 
   function generateOrder() {
     const type = pickWeighted(ORDER_TYPES, 'weight');
+    if (!type) return null;
     const id = Math.floor(1000 + Math.random() * 9000);
 
     let priority = 'Normal';

--- a/test/pickWeighted.test.js
+++ b/test/pickWeighted.test.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+
+function pickWeighted(arr, key) {
+  if (arr.length === 0) return null;
+  const total = arr.reduce((a, b) => a + b[key], 0);
+  if (total === 0) return null;
+  let r = Math.random() * total;
+  for (const it of arr) { r -= it[key]; if (r <= 0) return it; }
+  return arr[arr.length - 1];
+}
+
+assert.strictEqual(pickWeighted([], 'weight'), null, 'empty array returns null');
+assert.strictEqual(pickWeighted([{weight:0}, {weight:0}], 'weight'), null, 'zero weight returns null');
+
+console.log('All pickWeighted edge case tests passed.');


### PR DESCRIPTION
## Summary
- Return `null` when `pickWeighted` receives an empty array or one whose weights sum to zero
- Safeguard `generateOrder` against `null` from `pickWeighted`
- Add node-based test covering empty and zero-weight cases

## Testing
- `node test/pickWeighted.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6e6259c048326af790e2190ab7f27