### PR TITLE
Replace SVG factory view with dashboard layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,8 @@
     .daybar>span{display:block;height:100%;width:0;background:linear-gradient(90deg,#60a5fa,#93c5fd);transition:width 0.5s ease}
 
     #worldWrap{position:fixed;inset:56px 380px 0 0; background:var(--tile2);}
-    #worldSvg{width:100%;height:100%;display:block}
+    #dashboard{width:100%;height:100%;display:flex;gap:20px;padding:20px;overflow:auto}
+    #ordersColumn,#machinesColumn{flex:1}
     #paused{position:absolute;inset:0;display:none;align-items:center;justify-content:center;background:rgba(2,6,23,.15);font-size:42px;font-weight:900;color:#0f172a;z-index:5}
     #paused.show{display:flex}
 
@@ -127,7 +128,7 @@
   </div>
 
   <div id="worldWrap">
-    <svg id="worldSvg" xmlns="http://www.w3.org/2000/svg">
+    <!-- <svg id="worldSvg" xmlns="http://www.w3.org/2000/svg">
       <defs>
         <linearGradient id="gridGrad" x1="0" y1="0" x2="0" y2="1">
           <stop offset="0" stop-color="#f3f4f6"/>
@@ -157,7 +158,11 @@
         </filter>
       </defs>
       <g id="viewport"></g>
-    </svg>
+    </svg> -->
+    <div id="dashboard">
+      <div id="ordersColumn"></div>
+      <div id="machinesColumn"></div>
+    </div>
     <div id="paused">⏸ Paused</div>
   </div>
 
@@ -214,11 +219,9 @@
     completedOrders: [],
 
     // World
-    tiles: { w: 40, h: 24, size: 64 },
     entities: [],
 
-    // Camera & interaction
-    camera: { x: 0, y: 0, zoom: 1 },
+    // Interaction
     mode: 'inspect',
     build: { kind: 'washer' },
     hovered: null,
@@ -259,9 +262,7 @@
     automation: [2000, 5000, 10000]
   };
 
-  // SVG / viewport
-  const svg = $('#worldSvg');
-  const vp  = $('#viewport');
+  // Dashboard
 
   function showNotification(message, type = 'info', duration = 3000) {
     const notification = document.createElement('div');
@@ -348,7 +349,32 @@
     if (Math.random() < (0.001 + state.reputation * 0.0001) * delta) generateOrder();
 
     updateHUD();
-    draw();
+    renderDashboard();
+  }
+
+  // ===== Dashboard Rendering =====
+  function renderDashboard() {
+    const ordersHost = $('#ordersColumn');
+    const machinesHost = $('#machinesColumn');
+    if (!ordersHost || !machinesHost) return;
+
+    ordersHost.innerHTML = '';
+    machinesHost.innerHTML = '';
+
+    state.orders.forEach(order => {
+      const el = document.createElement('div');
+      el.className = `order ${order.priority.toLowerCase()}`;
+      el.innerHTML = `<strong>#${order.id} — ${order.label}</strong>`;
+      ordersHost.appendChild(el);
+    });
+
+    state.entities.forEach(entity => {
+      const type = MACHINE_TYPES[entity.kind];
+      const el = document.createElement('div');
+      el.className = 'machine-card';
+      el.innerHTML = `<strong>${type.label}</strong>`;
+      machinesHost.appendChild(el);
+    });
   }
 
   function finishStage(entity) {
@@ -641,7 +667,7 @@
             else showNotification('Not enough money to repair!', 'error');
           });
         } else {
-          button.addEventListener('click', () => { state.selected = entity.id; showNotification('Machine highlighted in factory view', 'info'); draw(); });
+          button.addEventListener('click', () => { state.selected = entity.id; showNotification('Machine highlighted in factory view', 'info'); renderDashboard(); });
         }
         managementSection.appendChild(el);
       });
@@ -753,152 +779,11 @@
     renderCurrentTab();
   }
 
-  // ===== Camera & input =====
-  const cam = state.camera; const tiles = state.tiles; let isPanning = false; let panStart = null;
-
-  function clientToSvg(evt) {
-    const m = svg.getScreenCTM(); if (!m) return { x: 0, y: 0 };
-    const pt = svg.createSVGPoint(); pt.x = evt.clientX; pt.y = evt.clientY; return pt.matrixTransform(m.inverse());
-  }
-  const svgToGrid = (x, y) => ({ gx: Math.floor((x - cam.x) / cam.zoom / tiles.size), gy: Math.floor((y - cam.y) / cam.zoom / tiles.size) });
-  const hitEntity = (gx, gy) => state.entities.find(e => gx >= e.x && gy >= e.y && gx < e.x + e.w && gy < e.y + e.h);
-
-  function canPlace(kind, gx, gy) {
-    const type = MACHINE_TYPES[kind]; if (!type) return false;
-    if (gx < 0 || gy < 0 || gx + type.w > tiles.w || gy + type.h > tiles.h) return false;
-    return !state.entities.some(e => !(gx + type.w <= e.x || e.x + e.w <= gx || gy + type.h <= e.y || e.y + e.h <= gy));
-  }
-
-  function tryPlace(gx, gy) {
-    const kind = state.build.kind; const type = MACHINE_TYPES[kind]; if (!type) return;
-    if (state.money < type.cost) { showNotification(`Need ${fmtMoney(type.cost)} to build ${type.label}`, 'error'); return; }
-    if (canPlace(kind, gx, gy)) { state.money -= type.cost; addEntity(kind, gx, gy); showNotification(`${type.label} built for ${fmtMoney(type.cost)}`, 'success'); updateHUD(); renderCurrentTab(); draw(); hideTip(); }
-    else showNotification('Cannot place machine here', 'error');
-  }
-
-  svg.addEventListener('mousedown', e => {
-    if (e.button === 1 || e.button === 2 || e.ctrlKey || e.metaKey || e.shiftKey) {
-      isPanning = true; panStart = { x: e.clientX, y: e.clientY, camX: cam.x, camY: cam.y }; e.preventDefault(); return;
-    }
-    const { x, y } = clientToSvg(e); const { gx, gy } = svgToGrid(x, y);
-    if (state.mode === 'build') { tryPlace(gx, gy); return; }
-    const entity = hitEntity(gx, gy);
-    if (state.mode === 'assign' && selectingOrder) {
-      if (entity && !entity.broken && !entity.job) {
-        const order = selectingOrder; const req = entity.kind.includes('washer') ? order.washerMin : entity.kind.includes('dryer') ? order.dryerMin : order.foldMin;
-        assignJob(entity, order, req);
-        const idx = state.orders.findIndex(x => x.id === order.id); if (idx > -1) state.orders.splice(idx, 1);
-        selectingOrder = null; state.mode = 'inspect';
-        showNotification(`Order assigned to ${MACHINE_TYPES[entity.kind].label}`, 'success');
-        hideTip(); renderOrders(); draw();
-      } else showNotification('Select an idle, working machine', 'warning');
-      return;
-    }
-    if (entity) { if (entity.broken) { const cost = 50; if (state.money >= cost) { state.money -= cost; entity.broken = false; entity.efficiency = Math.min(1, entity.efficiency + 0.05); showNotification(`Machine repaired for ${fmtMoney(cost)}`, 'success'); updateHUD(); draw(); } else showNotification(`Need ${fmtMoney(cost)} to repair`, 'error'); return; } state.selected = entity.id; draw(); }
-  });
-  svg.addEventListener('contextmenu', e => e.preventDefault());
-
-  window.addEventListener('mousemove', e => {
-    if (isPanning) {
-      const dx = (e.clientX - panStart.x) / cam.zoom; const dy = (e.clientY - panStart.y) / cam.zoom;
-      cam.x = clamp(panStart.camX - dx, 0, tiles.w * tiles.size - svg.clientWidth / cam.zoom);
-      cam.y = clamp(panStart.camY - dy, 0, tiles.h * tiles.size - svg.clientHeight / cam.zoom);
-      draw();
-    } else {
-      const { x, y } = clientToSvg(e); const { gx, gy } = svgToGrid(x, y); state.hovered = { gx, gy }; draw();
-    }
-  });
-  window.addEventListener('mouseup', () => { isPanning = false; });
-  svg.addEventListener('wheel', e => {
-    const oldZoom = cam.zoom; const newZoom = clamp(cam.zoom * (e.deltaY > 0 ? 0.9 : 1.1), 0.3, 3);
-    if (newZoom !== oldZoom) { const { x, y } = clientToSvg(e); const wx = (x - cam.x) * (newZoom / oldZoom); const wy = (y - cam.y) * (newZoom / oldZoom); cam.x = x - wx; cam.y = y - wy; cam.zoom = newZoom; draw(); }
-  }, { passive: true });
-
-  function draw() {
-    vp.setAttribute('transform', `translate(${cam.x},${cam.y}) scale(${cam.zoom})`);
-    drawGrid(); drawPlacementPreview(); drawEntities();
-  }
-
-  function drawGrid() {
-    const tilesW = tiles.w * tiles.size; const tilesH = tiles.h * tiles.size;
-    let grid = document.getElementById('grid'); if (!grid) { grid = document.createElementNS('http://www.w3.org/2000/svg', 'g'); grid.setAttribute('id', 'grid'); vp.appendChild(grid); }
-    grid.innerHTML = '';
-    grid.appendChild(svgEl('rect', { x: 0, y: 0, width: tilesW, height: tilesH, fill: 'url(#gridGrad)' }));
-    const gridLines = svgEl('g', { stroke: '#e5e7eb', 'stroke-width': Math.max(0.5, 1 / cam.zoom) });
-    const step = cam.zoom < 0.5 ? 5 : 1;
-    for (let x = 0; x <= tiles.w; x += step) gridLines.appendChild(svgEl('line', { x1: x * tiles.size, y1: 0, x2: x * tiles.size, y2: tilesH }));
-    for (let y = 0; y <= tiles.h; y += step) gridLines.appendChild(svgEl('line', { x1: 0, y1: y * tiles.size, x2: tilesW, y2: y * tiles.size }));
-    grid.appendChild(gridLines);
-  }
-
-  function drawPlacementPreview() {
-    const previewId = 'placePreview'; let preview = document.getElementById(previewId);
-    if (state.mode === 'build' && state.hovered) {
-      const type = MACHINE_TYPES[state.build.kind]; if (!type) return;
-      const { gx, gy } = state.hovered; const canAfford = state.money >= type.cost; const canPlaceHere = canPlace(state.build.kind, gx, gy); const ok = canAfford && canPlaceHere;
-      if (!preview) { preview = svgEl('rect', { id: previewId }); vp.appendChild(preview); }
-      preview.setAttribute('x', gx * tiles.size); preview.setAttribute('y', gy * tiles.size);
-      preview.setAttribute('width', type.w * tiles.size); preview.setAttribute('height', type.h * tiles.size);
-      preview.setAttribute('fill', !canAfford ? 'rgba(156,163,175,.5)' : ok ? 'rgba(34,197,94,.4)' : 'rgba(239,68,68,.4)');
-      preview.setAttribute('stroke', !canAfford ? '#9ca3af' : ok ? '#22c55e' : '#ef4444');
-      preview.setAttribute('stroke-width', 2); preview.setAttribute('rx', 8);
-    } else if (preview) preview.remove();
-  }
-
-  function drawEntities() {
-    let ents = document.getElementById('ents'); if (!ents) { ents = svgEl('g', { id: 'ents' }); vp.appendChild(ents); }
-    ents.innerHTML = '';
-    const sorted = [...state.entities].sort((a,b)=> (a.id===state.selected) - (b.id===state.selected));
-    for (const entity of sorted) ents.appendChild(drawMachine(entity));
-  }
-
-  function drawMachine(entity) {
-    const type = MACHINE_TYPES[entity.kind];
-    const g = svgEl('g', { filter: 'url(#cardShadow)', style: entity.id === state.selected ? 'filter: url(#glow)' : '' });
-    const x = entity.x * tiles.size, y = entity.y * tiles.size, w = entity.w * tiles.size, h = entity.h * tiles.size;
-
-    const bodyColor = entity.broken ? '#fee2e2' : '#ffffff';
-    g.appendChild(svgEl('rect', { x: x + 4, y: y + 4, width: w - 8, height: h - 8, rx: 12, ry: 12, fill: bodyColor, stroke: '#cbd5e1', 'stroke-width': 2 }));
-    const headerColor = entity.broken ? '#fca5a5' : type.color;
-    g.appendChild(svgEl('rect', { x: x + 4, y: y + 4, width: w - 8, height: 28, rx: 10, ry: 10, fill: headerColor }));
-
-    g.appendChild(svgEl('text', { x: x + 16, y: y + 24, fill: '#fff', 'font-size': 14, 'font-family': 'ui-sans-serif', 'font-weight': '700' })).textContent = type.label.split(' ')[0];
-
-    let status = entity.broken ? 'BROKEN - Click to repair' : entity.job ? `${entity.job.label} (${entity.job.stage})` : 'Idle';
-    if (status.length > 20) status = status.substring(0, 17) + '...';
-    g.appendChild(svgEl('text', { x: x + 16, y: y + 46, fill: entity.broken ? '#dc2626' : '#1f2937', 'font-size': 12, 'font-family': 'ui-sans-serif' })).textContent = status;
-
-    if (entity.job && !entity.broken) {
-      const progress = Math.min(1, entity.progress / entity.job.req);
-      const barX = x + 12, barY = y + h - 32, barW = w - 24, barH = 14;
-      g.appendChild(svgEl('rect', { x: barX, y: barY, width: barW, height: barH, rx: 7, ry: 7, fill: '#e5e7eb' }));
-      if (progress > 0) g.appendChild(svgEl('rect', { x: barX, y: barY, width: barW * progress, height: barH, rx: 7, ry: 7, fill: state.running ? 'url(#progressBlue)' : '#cbd5e1' }));
-      const remaining = Math.max(0, entity.job.req - entity.progress);
-      const seconds = Math.ceil(remaining / Math.max(0.1, state.speed * entity.speed));
-      const minutes = Math.floor(seconds / 60), secs = seconds % 60, timeText = minutes > 0 ? `${minutes}m ${secs}s` : `${secs}s`;
-      g.appendChild(svgEl('text', { x: barX + barW / 2, y: barY + 10, 'text-anchor': 'middle', fill: '#fff', 'font-size': 10, 'font-family': 'ui-sans-serif', 'font-weight': '600' })).textContent = `${Math.round(progress * 100)}% • ${timeText}`;
-    }
-
-    const efficiencyColor = entity.efficiency > 0.8 ? '#10b981' : entity.efficiency > 0.6 ? '#f59e0b' : '#ef4444';
-    g.appendChild(svgEl('circle', { cx: x + w - 16, cy: y + 20, r: 6, fill: efficiencyColor, stroke: '#fff', 'stroke-width': 2 }));
-
-    if (entity.job && !entity.broken && state.running) {
-      const indicator = svgEl('circle', { cx: x + w - 16, cy: y + h - 16, r: 4, fill: '#22c55e' });
-      const animate = svgEl('animate', { attributeName: 'opacity', values: '0.3;1;0.3', dur: '1s', repeatCount: 'indefinite' });
-      indicator.appendChild(animate); g.appendChild(indicator);
-    }
-
-    if (state.selected === entity.id) g.appendChild(svgEl('rect', { x: x + 2, y: y + 2, width: w - 4, height: h - 4, fill: 'none', stroke: '#0b67c2', 'stroke-width': 3, rx: 10, ry: 10, 'stroke-dasharray': '8,4' }));
-
-    return g;
-  }
-
-  function svgEl(tag, attrs) { const el = document.createElementNS('http://www.w3.org/2000/svg', tag); if (attrs) for (const [k,v] of Object.entries(attrs)) el.setAttribute(k, v); return el; }
 
   // ===== Save / Load =====
   function save() {
-    const { version, day, minutes, speed, baseRate, money, energyPct, energyCostToday, totalEarnings, reputation, doneToday, breakdownsToday, totalCompleted, customerSatisfaction, orders, orderBook, completedOrders, tiles, entities, upgrades } = state;
-    const saveData = { version, day, minutes, speed, baseRate, money, energyPct, energyCostToday, totalEarnings, reputation, doneToday, breakdownsToday, totalCompleted, customerSatisfaction, orders, orderBook, completedOrders, tiles, entities, upgrades, savedAt: Date.now() };
+    const { version, day, minutes, speed, baseRate, money, energyPct, energyCostToday, totalEarnings, reputation, doneToday, breakdownsToday, totalCompleted, customerSatisfaction, orders, orderBook, completedOrders, entities, upgrades } = state;
+    const saveData = { version, day, minutes, speed, baseRate, money, energyPct, energyCostToday, totalEarnings, reputation, doneToday, breakdownsToday, totalCompleted, customerSatisfaction, orders, orderBook, completedOrders, entities, upgrades, savedAt: Date.now() };
     localStorage.setItem('cozyLaundryEnhanced', JSON.stringify(saveData)); showNotification('Game saved successfully!', 'success');
   }
   function load() {
@@ -934,11 +819,11 @@
     const loaded = load();
     if (!loaded) placeDefaultMachines();
     state.speed = parseFloat($('#speed').value); $('#speedVal').textContent = state.speed.toFixed(1) + '×';
-    updateHUD(); setTab('orders'); draw(); updatePauseButton();
+    updateHUD(); setTab('orders'); renderDashboard(); updatePauseButton();
     requestAnimationFrame(gameLoop);
     showNotification('🧺 Welcome to Cozy Laundry Enhanced!', 'success', 4000);
   }
-  window.addEventListener('resize', () => { setTimeout(draw, 100); });
+  window.addEventListener('resize', () => { setTimeout(renderDashboard, 100); });
   window.addEventListener('keydown', (e) => {
     if (e.target.tagName === 'INPUT') return;
     switch(e.key.toLowerCase()) {
@@ -955,7 +840,7 @@
         const order = selectingOrder; const req = targetType === 'washer' ? order.washerMin : targetType === 'dryer' ? order.dryerMin : order.foldMin;
         assignJob(target, order, req);
         const idx = state.orders.findIndex(x => x.id === order.id); if (idx > -1) state.orders.splice(idx, 1);
-        selectingOrder = null; state.mode = 'inspect'; hideTip(); showNotification('Order assigned via keyboard shortcut!', 'success'); renderOrders(); draw();
+        selectingOrder = null; state.mode = 'inspect'; hideTip(); showNotification('Order assigned via keyboard shortcut!', 'success'); renderOrders(); renderDashboard();
       } else showNotification(`No available ${targetType}`, 'warning');
     }
   });
@@ -968,8 +853,8 @@
     addMoney: (amount) => { state.money += amount; updateHUD(); showNotification(`Added ${fmtMoney(amount)}`, 'success'); },
     addReputation: (amount) => { state.reputation += amount; updateHUD(); showNotification(`Added ${amount} reputation`, 'success'); },
     completeAllOrders: () => { state.orders.forEach(order => completeOrder(order)); state.orders = []; renderOrders(); },
-    breakAllMachines: () => { state.entities.forEach(entity => entity.broken = true); draw(); showNotification('All machines broken!', 'error'); },
-    fixAllMachines: () => { state.entities.forEach(entity => { entity.broken = false; entity.efficiency = 1; }); draw(); showNotification('All machines repaired!', 'success'); },
+    breakAllMachines: () => { state.entities.forEach(entity => entity.broken = true); renderDashboard(); showNotification('All machines broken!', 'error'); },
+    fixAllMachines: () => { state.entities.forEach(entity => { entity.broken = false; entity.efficiency = 1; }); renderDashboard(); showNotification('All machines repaired!', 'success'); },
     skipToNextDay: () => { state.minutes = 22 * 60; tick(0); }
   };
 })();


### PR DESCRIPTION
## Summary
- swap factory SVG for a dashboard with orders and machines columns
- remove camera/tiles state and old SVG drawing functions
- render dashboard cards for orders and machines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e70bc1b08326960f371c166bb643