### PR TITLE
Switch factory tick rendering to dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,9 @@
     .daybar>span{display:block;height:100%;width:0;background:linear-gradient(90deg,#60a5fa,#93c5fd);transition:width 0.5s ease}
 
     #worldWrap{position:fixed;inset:56px 380px 0 0; background:var(--tile2);}
+    #dashboard{position:absolute;inset:0;overflow:auto;padding:10px;display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:10px}
+    .progress-bar{height:8px;background:#e5e7eb;border-radius:4px;overflow:hidden;margin-top:4px}
+    .progress-fill{height:100%;background:linear-gradient(90deg,#60a5fa,#3b82f6);transition:width 0.2s ease}
     #worldSvg{width:100%;height:100%;display:block}
     #paused{position:absolute;inset:0;display:none;align-items:center;justify-content:center;background:rgba(2,6,23,.15);font-size:42px;font-weight:900;color:#0f172a;z-index:5}
     #paused.show{display:flex}
@@ -127,6 +130,7 @@
   </div>
 
   <div id="worldWrap">
+    <div id="dashboard"></div>
     <svg id="worldSvg" xmlns="http://www.w3.org/2000/svg">
       <defs>
         <linearGradient id="gridGrad" x1="0" y1="0" x2="0" y2="1">
@@ -348,7 +352,7 @@
     if (Math.random() < (0.001 + state.reputation * 0.0001) * delta) generateOrder();
 
     updateHUD();
-    draw();
+    renderDashboard();
   }
 
   function finishStage(entity) {
@@ -737,10 +741,27 @@
               <div style="font-size:12px;color:#6b7280">Utilization</div>
             </div>
           </div>`;
-        machineSection.appendChild(el);
+      machineSection.appendChild(el);
       });
       host.appendChild(machineSection);
     }
+  }
+
+  function renderDashboard() {
+    const host = $('#dashboard'); if (!host) return; host.innerHTML = '';
+    state.entities.forEach((entity, index) => {
+      const type = MACHINE_TYPES[entity.kind];
+      const card = document.createElement('div');
+      card.className = 'machine-card';
+      const progress = entity.job ? entity.progress / entity.job.req : 0;
+      const pct = Math.round(Math.max(0, Math.min(1, progress)) * 100);
+      const status = entity.broken ? '🔧 Broken' : entity.job ? `${entity.job.label}` : 'Idle';
+      card.innerHTML = `
+        <strong>${type.label} #${index + 1}</strong>
+        <div class="machine-specs">${status}${entity.job ? ` — ${pct}%` : ''}</div>
+        <div class="progress-bar"><div class="progress-fill" style="width:${pct}%"></div></div>`;
+      host.appendChild(card);
+    });
   }
 
   // ===== Tabs =====


### PR DESCRIPTION
## Summary
- Render machines in a dashboard view with per-job progress bars
- Update tick loop to call `renderDashboard` instead of `draw`
- Add dashboard container and basic progress bar styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e70e3a1483268ac8dfb7a4c4a19a