### PR TITLE
style: add dashboard layout and drag states

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
     :root{
       --ink:#0b0f1a; --muted:#6b7280; --bg:#f6f8fb; --card:#ffffff; --brand:#0b67c2; --ring:#c7d2fe; --grid:#e6e9ef; --shadow:0 12px 28px rgba(2,6,23,.08);
       --good:#10b981; --warn:#f59e0b; --bad:#ef4444; --blue:#3b82f6; --blue2:#60a5fa;
-      --tile:#e5e7eb; --tile2:#f3f4f6; --belt:#cbd5e1;
     }
     *{box-sizing:border-box}
     html,body{height:100%}
@@ -27,11 +26,6 @@
     .daybar{height:6px;background:#eef2ff;border-top:1px solid #e5e7eb}
     .daybar>span{display:block;height:100%;width:0;background:linear-gradient(90deg,#60a5fa,#93c5fd);transition:width 0.5s ease}
 
-    #worldWrap{position:fixed;inset:56px 380px 0 0; background:var(--tile2);}
-    #worldSvg{width:100%;height:100%;display:block}
-    #paused{position:absolute;inset:0;display:none;align-items:center;justify-content:center;background:rgba(2,6,23,.15);font-size:42px;font-weight:900;color:#0f172a;z-index:5}
-    #paused.show{display:flex}
-
     #sidebar{position:fixed;top:56px;right:0;bottom:0;width:380px;background:var(--card);border-left:1px solid var(--grid);box-shadow:var(--shadow);display:grid;grid-template-rows:auto 1fr;padding:10px}
     .tabs{display:flex;gap:6px}
     .tab{flex:1 0 auto;border:1px solid var(--grid);background:#fff;padding:8px 12px;border-radius:10px;cursor:pointer;text-align:center;transition:all 0.2s;font-weight:600}
@@ -41,10 +35,14 @@
 
     .section{margin-bottom:20px}
     .h{font-size:12px;font-weight:800;color:#475569;letter-spacing:.12em;text-transform:uppercase;margin:8px 6px 6px 6px}
-    .order{border:1px solid var(--grid);border-radius:12px;padding:12px;margin:6px;background:#fff;display:grid;gap:8px;transition:all 0.2s}
-    .order:hover{box-shadow:0 4px 12px rgba(0,0,0,0.1);transform:translateY(-1px)}
-    .order.urgent{border-color:#f59e0b;background:#fffbeb}
-    .order.rush{border-color:#ef4444;background:#fef2f2}
+    #dashboard{display:grid;grid-template-columns:1fr 1fr;gap:16px;height:calc(100vh - 56px);padding:20px}
+    #ordersColumn,#machinesColumn{display:flex;flex-direction:column;gap:12px;overflow:auto}
+
+    .order-card,.order{border:1px solid var(--grid);border-radius:12px;padding:12px;background:var(--card);display:grid;gap:8px;transition:box-shadow .2s,transform .2s;cursor:grab}
+    .order-card:hover,.order:hover{box-shadow:0 4px 12px rgba(0,0,0,0.1);transform:translateY(-1px)}
+    .order-card.active,.order.active{border-color:var(--brand);box-shadow:0 0 0 2px var(--ring)}
+    .order-card.urgent,.order.urgent{border-color:#f59e0b;background:#fffbeb}
+    .order-card.rush,.order.rush{border-color:#ef4444;background:#fef2f2}
 
     .badgel{display:inline-flex;gap:6px;align-items:center;flex-wrap:wrap}
     .tag{font-size:11px;padding:3px 8px;border:1px solid var(--grid);border-radius:999px;background:#f1f5f9;color:#334155;font-weight:600}
@@ -52,8 +50,9 @@
     .tag.urgent{background:#fef3c7;border-color:#fcd34d;color:#92400e}
     .tag.completed{background:#d1fae5;border-color:#86efac;color:#065f46}
 
-    .machine-card{border:1px solid var(--grid);border-radius:12px;padding:12px;margin:6px;background:#fff;transition:all 0.2s}
-    .machine-card:hover{box-shadow:0 4px 12px rgba(0,0,0,0.1)}
+    .machine-card{border:1px solid var(--grid);border-radius:12px;padding:12px;background:var(--card);transition:box-shadow .2s,transform .2s;cursor:grab}
+    .machine-card:hover{box-shadow:0 4px 12px rgba(0,0,0,0.1);transform:translateY(-1px)}
+    .machine-card.active{border-color:var(--brand);box-shadow:0 0 0 2px var(--ring)}
     .machine-price{color:var(--bad);font-weight:700}
     .machine-specs{font-size:12px;color:var(--muted);margin:6px 0}
 
@@ -92,8 +91,10 @@
 
     [aria-live]{position:fixed;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden}
 
+    .dragging{opacity:0.6;cursor:grabbing!important}
+    .drop-target{outline:2px dashed var(--brand);outline-offset:2px}
+
     @media (max-width: 1200px) {
-      #worldWrap{right:320px}
       #sidebar{width:320px}
     }
     @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- add grid layout for upcoming dashboard with orders and machines columns
- style order and machine cards with hover/active states
- add dragging and drop-target visual feedback
- remove old SVG world styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e70f975c83268949ac5bbad4696e