### PR TITLE
Explain drag-and-drop order assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Cozy Laundry Game
+
+Cozy Laundry is a small factory management prototype played in the browser. The interface presents a live dashboard with a world view on the left and a sidebar for orders, construction, upgrades and stats.
+
+## Drag-and-drop Orders
+
+Orders appear in the **Orders** tab of the sidebar. To start work, drag an order card from the list onto an idle machine in the world view. The machine immediately begins processing the job. Use the **Assign** button or press Esc to cancel while dragging.
+
+## Interface
+
+- **HUD** – shows the current day, money, energy and reputation.
+- **World view** – displays the laundrette floor where machines operate.
+- **Sidebar** – switch between orders, building options, upgrades and stats.
+- **Help** – keyboard shortcuts and tips are shown at the bottom left.
+
+This repository contains the static HTML, CSS and JavaScript files required to run the demo.

--- a/index.html
+++ b/index.html
@@ -175,6 +175,7 @@
   <div id="tip" class="overlay-tip"></div>
   <div class="help" title="Keyboard shortcuts">
     <div><strong>Keys:</strong> <kbd>Space</kbd>/<kbd>P</kbd> Pause • <kbd>1-4</kbd> Tabs • <kbd>A</kbd> Add Order • <kbd>Ctrl/⌘+S</kbd> Save • <kbd>Esc</kbd> Cancel Mode</div>
+    <div>Drag orders onto machines to assign them</div>
   </div>
 
 <script>
@@ -536,7 +537,7 @@
         `;
 
         el.querySelector('.btn-assign').addEventListener('click', () => {
-          state.mode = 'assign'; selectingOrder = order; showTip('Click an idle machine to assign this order. Esc to cancel.');
+          state.mode = 'assign'; selectingOrder = order; showTip('Drag this order onto an idle machine. Esc to cancel.');
         });
         el.querySelector('.btn-cancel').addEventListener('click', () => {
           const penalty = Math.round(order.pay * 0.1);


### PR DESCRIPTION
## Summary
- Document dashboard layout and drag-and-drop order assignment in a new README
- Update help overlay and tip text to guide players to drag orders onto machines

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e714bbb88326b159774f0518f4db