### PR TITLE
refactor: move pickWeighted logic to shared util

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@
     <div><strong>Keys:</strong> <kbd>Space</kbd>/<kbd>P</kbd> Pause • <kbd>1-4</kbd> Tabs • <kbd>A</kbd> Add Order • <kbd>Ctrl/⌘+S</kbd> Save • <kbd>Esc</kbd> Cancel Mode</div>
     <div>Drag orders onto machines to assign them</div>
   </div>
-
+<script src="js/utils.js"></script>
 <script>
 ;(() => {
   // ===== Helpers =====
@@ -294,15 +294,6 @@
       notification.style.animation = 'slideIn 0.3s ease reverse';
       setTimeout(() => notification.remove(), 300);
     }, duration);
-  }
-
-  function pickWeighted(arr, key) {
-    if (arr.length === 0) return null;
-    const total = arr.reduce((a, b) => a + b[key], 0);
-    if (total === 0) return null;
-    let r = Math.random() * total;
-    for (const it of arr) { r -= it[key]; if (r <= 0) return it; }
-    return arr[arr.length - 1];
   }
 
   function generateOrder() {

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,19 @@
+function pickWeighted(arr, key) {
+  if (!Array.isArray(arr) || arr.length === 0) return null;
+  const total = arr.reduce((a, b) => a + b[key], 0);
+  if (total <= 0) return null;
+  let r = Math.random() * total;
+  for (const it of arr) {
+    r -= it[key];
+    if (r <= 0) return it;
+  }
+  return arr[arr.length - 1];
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { pickWeighted };
+}
+
+if (typeof window !== 'undefined') {
+  window.pickWeighted = pickWeighted;
+}

--- a/test/pickWeighted.test.js
+++ b/test/pickWeighted.test.js
@@ -1,13 +1,5 @@
 const assert = require('assert');
-
-function pickWeighted(arr, key) {
-  if (arr.length === 0) return null;
-  const total = arr.reduce((a, b) => a + b[key], 0);
-  if (total === 0) return null;
-  let r = Math.random() * total;
-  for (const it of arr) { r -= it[key]; if (r <= 0) return it; }
-  return arr[arr.length - 1];
-}
+const { pickWeighted } = require('../js/utils');
 
 assert.strictEqual(pickWeighted([], 'weight'), null, 'empty array returns null');
 assert.strictEqual(pickWeighted([{weight:0}, {weight:0}], 'weight'), null, 'zero weight returns null');


### PR DESCRIPTION
## Summary
- expose pickWeighted helper in js/utils.js for reuse in browser and tests
- load shared util in index.html and remove inlined pickWeighted implementation
- update tests to import helper instead of duplicating code

## Testing
- `node test/pickWeighted.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6eecb19048326845447eef1517067