### PR TITLE
Handle invalid weights in pickWeighted

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -1,13 +1,26 @@
 function pickWeighted(arr, key) {
   if (!Array.isArray(arr) || arr.length === 0) return null;
-  const total = arr.reduce((a, b) => a + b[key], 0);
-  if (total <= 0) return null;
-  let r = Math.random() * total;
+
+  const valid = [];
   for (const it of arr) {
+    const w = it[key];
+    if (typeof w !== 'number' || !Number.isFinite(w) || w < 0) {
+      continue; // Skip invalid weights
+    }
+    valid.push(it);
+  }
+
+  if (valid.length === 0) return null;
+
+  const total = valid.reduce((sum, item) => sum + item[key], 0);
+  if (total <= 0) return null;
+
+  let r = Math.random() * total;
+  for (const it of valid) {
     r -= it[key];
     if (r <= 0) return it;
   }
-  return arr[arr.length - 1];
+  return valid[valid.length - 1];
 }
 
 if (typeof module !== 'undefined') {

--- a/test/pickWeighted.test.js
+++ b/test/pickWeighted.test.js
@@ -3,5 +3,12 @@ const { pickWeighted } = require('../js/utils');
 
 assert.strictEqual(pickWeighted([], 'weight'), null, 'empty array returns null');
 assert.strictEqual(pickWeighted([{weight:0}, {weight:0}], 'weight'), null, 'zero weight returns null');
+const mixed = [{weight:2}, {weight:'a'}, {weight:-1}];
+assert.strictEqual(pickWeighted(mixed, 'weight'), mixed[0], 'invalid weights skipped');
+assert.strictEqual(
+  pickWeighted([{weight:'x'}, {missing:1}, {weight:-5}], 'weight'),
+  null,
+  'all invalid weights return null'
+);
 
 console.log('All pickWeighted edge case tests passed.');


### PR DESCRIPTION
## Summary
- validate weight values before summing
- ignore invalid weight entries and handle all-invalid arrays
- test additional edge cases for invalid weights

## Testing
- `node test/pickWeighted.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6f57a1f988326a5c30a5de437c483