### PR TITLE
Fix game initialization by removing stray closing script tag

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -889,4 +889,3 @@
     skipToNextDay: () => { state.minutes = 22 * 60; tick(0); }
   };
 })();
-</script>


### PR DESCRIPTION
## Summary
- Remove stray `</script>` tag in `game.js` that prevented the game's JavaScript from loading, allowing the dashboard to populate.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f70055c88326a13c383180c4ca23