### PR TITLE
Handle invalid weights in pickWeighted

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -1,13 +1,24 @@
 function pickWeighted(arr, key) {
   if (!Array.isArray(arr) || arr.length === 0) return null;
-  const total = arr.reduce((a, b) => a + b[key], 0);
+
+  const getWeight = (it) => {
+    const w = Number(it && it[key]);
+    return Number.isFinite(w) && w > 0 ? w : 0;
+  };
+
+  const total = arr.reduce((sum, it) => sum + getWeight(it), 0);
   if (total <= 0) return null;
+
   let r = Math.random() * total;
+  let lastValid = null;
   for (const it of arr) {
-    r -= it[key];
+    const w = getWeight(it);
+    if (w === 0) continue;
+    lastValid = it;
+    r -= w;
     if (r <= 0) return it;
   }
-  return arr[arr.length - 1];
+  return lastValid;
 }
 
 if (typeof module !== 'undefined') {

--- a/test/pickWeighted.test.js
+++ b/test/pickWeighted.test.js
@@ -7,11 +7,28 @@ assert.strictEqual(pickWeighted([{ weight: 0 }, { weight: 0 }], 'weight'), null,
 
 // Negative weights
 assert.strictEqual(pickWeighted([{ weight: -1 }], 'weight'), null, 'negative weight returns null');
-assert.strictEqual(pickWeighted([{ weight: 2 }, { weight: -2 }], 'weight'), null, 'mixed negative weights return null');
+const mixedNegative = [{ weight: 2 }, { weight: -2 }];
+assert.strictEqual(pickWeighted(mixedNegative, 'weight'), mixedNegative[0], 'negative weights are skipped');
 
 // Missing weights
 const missing = [{ weight: 1 }, { value: 2 }];
-assert.strictEqual(pickWeighted(missing, 'weight'), missing[1], 'missing weights default to last element');
+assert.strictEqual(pickWeighted(missing, 'weight'), missing[0], 'items missing weight are skipped');
+
+// Invalid weights (NaN, Infinity, strings, non-positive)
+const invalid = [
+  { weight: 1 },
+  { weight: NaN },
+  { weight: Infinity },
+  { weight: -Infinity },
+  { weight: '2' },
+  { weight: -1 },
+  { weight: 0 },
+];
+assert.strictEqual(pickWeighted(invalid, 'weight'), invalid[0], 'invalid weights are skipped');
+
+// All invalid weights
+const allInvalid = [{}, { weight: 'x' }, { weight: NaN }];
+assert.strictEqual(pickWeighted(allInvalid, 'weight'), null, 'all invalid weights return null');
 
 // Deterministic behavior via mock Math.random
 const originalRandom = Math.random;


### PR DESCRIPTION
## Summary
- Ignore items with missing, non-finite, or non-positive weights when selecting
- Add comprehensive tests for negative, missing, and invalid weights

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f72df5848326af4d880f7ce36ab9