### PR TITLE
Add core test suite for order generation and persistence

### DIFF
--- a/js/gameCore.js
+++ b/js/gameCore.js
@@ -1,0 +1,128 @@
+const { pickWeighted } = require('./utils');
+
+const ORDER_TYPES = [
+  { key:'towels', label:'Hotel Towels', pay: 45, washerMin: 90, dryerMin: 80, foldMin: 50, weight: 1.2 },
+  { key:'sheets', label:'Bed Sheets', pay: 65, washerMin: 110, dryerMin: 100, foldMin: 80, weight: 1.0 },
+  { key:'scrubs', label:'Medical Scrubs', pay: 75, washerMin: 95, dryerMin: 90, foldMin: 70, weight: 0.8 },
+  { key:'duvets', label:'Duvets & Comforters', pay: 120, washerMin: 180, dryerMin: 160, foldMin: 100, weight: 0.4 },
+  { key:'uniforms', label:'Work Uniforms', pay: 55, washerMin: 85, dryerMin: 75, foldMin: 60, weight: 0.9 },
+  { key:'delicates', label:'Delicate Items', pay: 85, washerMin: 120, dryerMin: 110, foldMin: 90, weight: 0.5 }
+];
+
+const state = {
+  version: 11,
+  day: 1,
+  minutes: 6 * 60,
+  running: false,
+  speed: 1,
+  baseRate: 0.7,
+  money: 1500,
+  energyPct: 100,
+  energyCostToday: 0,
+  totalEarnings: 0,
+  reputation: 0,
+  doneToday: 0,
+  breakdownsToday: 0,
+  totalCompleted: 0,
+  customerSatisfaction: 100,
+  orders: [],
+  orderBook: {},
+  completedOrders: [],
+  tiles: { w: 40, h: 24, size: 64 },
+  entities: [],
+  upgrades: {
+    efficiency: 0,
+    powerSaving: 0,
+    reliability: 0,
+    reputation: 0,
+    automation: 0
+  }
+};
+
+function generateOrder() {
+  const type = pickWeighted(ORDER_TYPES, 'weight');
+  if (!type) return null;
+  const id = Math.floor(1000 + Math.random() * 9000);
+
+  let priority = 'Normal';
+  let payMultiplier = 1;
+  const rnd = Math.random();
+  if (rnd < 0.1) { priority = 'Rush'; payMultiplier = 1.5; }
+  else if (rnd < 0.3) { priority = 'Urgent'; payMultiplier = 1.2; }
+
+  const dayMultiplier = 1 + (state.day - 1) * 0.1;
+
+  const order = {
+    id,
+    type: type.key,
+    label: type.label,
+    priority,
+    pay: Math.round(type.pay * payMultiplier * dayMultiplier),
+    stage: 'queue',
+    washerMin: Math.round(type.washerMin * dayMultiplier),
+    dryerMin: Math.round(type.dryerMin * dayMultiplier),
+    foldMin: Math.round(type.foldMin * dayMultiplier),
+    createdAt: state.minutes,
+    deadline: state.minutes + (priority === 'Rush' ? 240 : priority === 'Urgent' ? 360 : 480)
+  };
+
+  state.orders.push(order);
+  state.orderBook[id] = order;
+  return order;
+}
+
+function assignJob(entity, order, req) {
+  const stage = entity.kind.includes('washer') ? 'wash'
+              : entity.kind.includes('dryer') ? 'dry'
+              : 'fold';
+  entity.job = {
+    id: order.id,
+    label: order.label,
+    stage,
+    req: Math.round(req * (1 - state.upgrades.efficiency * 0.1))
+  };
+  entity.progress = 0;
+}
+
+function saveGame() {
+  const {
+    version, day, minutes, speed, baseRate, money, energyPct, energyCostToday,
+    totalEarnings, reputation, doneToday, breakdownsToday, totalCompleted,
+    customerSatisfaction, orders, orderBook, completedOrders, tiles, entities, upgrades
+  } = state;
+  const saveData = {
+    version, day, minutes, speed, baseRate, money, energyPct, energyCostToday,
+    totalEarnings, reputation, doneToday, breakdownsToday, totalCompleted,
+    customerSatisfaction, orders, orderBook, completedOrders, tiles, entities, upgrades,
+    savedAt: Date.now()
+  };
+  localStorage.setItem('cozyLaundryEnhanced', JSON.stringify(saveData));
+}
+
+function loadGame() {
+  const saved = localStorage.getItem('cozyLaundryEnhanced');
+  if (!saved) return false;
+  const data = JSON.parse(saved);
+  Object.assign(state, { ...state, ...data, running: false });
+  return true;
+}
+
+// simple in-memory localStorage for non-browser environments
+if (typeof localStorage === 'undefined') {
+  let store = {};
+  global.localStorage = {
+    getItem(key) { return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null; },
+    setItem(key, value) { store[key] = String(value); },
+    removeItem(key) { delete store[key]; },
+    clear() { store = {}; }
+  };
+}
+
+module.exports = {
+  state,
+  ORDER_TYPES,
+  generateOrder,
+  assignJob,
+  saveGame,
+  loadGame
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "node test/pickWeighted.test.js"
+    "test": "node test/pickWeighted.test.js && node test/orderGeneration.test.js && node test/assignJob.test.js && node test/saveLoad.test.js"
   },
   "keywords": [],
   "author": "",

--- a/test/assignJob.test.js
+++ b/test/assignJob.test.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+const { state, assignJob } = require('../js/gameCore');
+
+// Assign job to washer
+state.upgrades.efficiency = 0;
+const washer = { kind: 'washer', progress: 5 };
+const order = { id: 1, label: 'Test Order' };
+assignJob(washer, order, 100);
+assert.deepStrictEqual(washer.job, {
+  id: 1,
+  label: 'Test Order',
+  stage: 'wash',
+  req: 100
+});
+assert.strictEqual(washer.progress, 0);
+
+// Efficiency upgrade reduces required minutes
+state.upgrades.efficiency = 2; // 20% reduction
+const dryer = { kind: 'dryer', progress: 10 };
+assignJob(dryer, order, 200);
+assert.deepStrictEqual(dryer.job, {
+  id: 1,
+  label: 'Test Order',
+  stage: 'dry',
+  req: Math.round(200 * 0.8)
+});
+assert.strictEqual(dryer.progress, 0);
+
+console.log('Machine assignment tests passed.');

--- a/test/orderGeneration.test.js
+++ b/test/orderGeneration.test.js
@@ -1,0 +1,49 @@
+const assert = require('assert');
+const { state, ORDER_TYPES, generateOrder } = require('../js/gameCore');
+
+function withMockedRandom(values, fn) {
+  const orig = Math.random;
+  let i = 0;
+  Math.random = () => {
+    const v = values[i];
+    i++;
+    return v;
+  };
+  try {
+    fn();
+  } finally {
+    Math.random = orig;
+  }
+}
+
+// Test rush order generation and state bookkeeping
+state.orders = [];
+state.orderBook = {};
+state.day = 1;
+state.minutes = 0;
+withMockedRandom([0, 0, 0], () => {
+  const order = generateOrder();
+  assert.strictEqual(order.type, ORDER_TYPES[0].key);
+  assert.strictEqual(order.priority, 'Rush');
+  assert.strictEqual(order.pay, Math.round(ORDER_TYPES[0].pay * 1.5));
+  assert.ok(state.orders.includes(order), 'order added to state.orders');
+  assert.strictEqual(state.orderBook[order.id], order, 'order stored in orderBook');
+  assert.strictEqual(order.deadline, state.minutes + 240, 'rush orders have shorter deadlines');
+});
+
+// Day multiplier affects payouts and requirements
+state.orders = [];
+state.orderBook = {};
+state.day = 3; // 20% increase
+state.minutes = 60;
+withMockedRandom([0, 0, 0.5], () => {
+  const order = generateOrder();
+  const mult = 1 + (state.day - 1) * 0.1;
+  assert.strictEqual(order.priority, 'Normal');
+  assert.strictEqual(order.pay, Math.round(ORDER_TYPES[0].pay * mult));
+  assert.strictEqual(order.washerMin, Math.round(ORDER_TYPES[0].washerMin * mult));
+  assert.strictEqual(order.dryerMin, Math.round(ORDER_TYPES[0].dryerMin * mult));
+  assert.strictEqual(order.foldMin, Math.round(ORDER_TYPES[0].foldMin * mult));
+});
+
+console.log('Order generation tests passed.');

--- a/test/saveLoad.test.js
+++ b/test/saveLoad.test.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+const { state, saveGame, loadGame } = require('../js/gameCore');
+
+// Ensure clean storage
+localStorage.clear();
+
+// Prepare state and save
+state.money = 2500;
+state.orders = [{ id: 42, label: 'Order' }];
+state.orderBook = { 42: state.orders[0] };
+saveGame();
+assert.ok(localStorage.getItem('cozyLaundryEnhanced'), 'state saved to localStorage');
+
+// Mutate state and load
+state.money = 0;
+state.orders = [];
+state.orderBook = {};
+state.running = true;
+const loaded = loadGame();
+assert.strictEqual(loaded, true);
+assert.strictEqual(state.money, 2500);
+assert.strictEqual(state.orders.length, 1);
+assert.strictEqual(state.orderBook[42].id, 42);
+assert.strictEqual(state.running, false, 'loading stops the game');
+
+console.log('Save/load tests passed.');


### PR DESCRIPTION
## Summary
- expose core game logic in new `gameCore` module for testing
- add tests for order generation, machine assignment and save/load
- run all tests via npm script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f731ed248326986e9ab65f6d40ff